### PR TITLE
Rename Keycloak env vars to NukeAuth prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ PUBLIC_CONTACT_API_URL=https://api.nukehub.org/contact
 # Leave empty to disable analytics entirely.
 PUBLIC_CF_ANALYTICS_TOKEN=
 
-# Keycloak Configuration (public - used by browser)
+# NukeAuth Configuration (public - used by browser)
 # These are safe to expose to the frontend
-PUBLIC_KEYCLOAK_URL=https://auth.nukehub.org
-PUBLIC_KEYCLOAK_REALM=nukehub
-PUBLIC_KEYCLOAK_CLIENT_ID=nukehub-web
+PUBLIC_AUTH_URL=https://auth.nukehub.org
+PUBLIC_AUTH_REALM=nukehub
+PUBLIC_AUTH_CLIENT_ID=nukehub-web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,8 +240,8 @@ browser. They are defined in `.env` (local dev) and Cloudflare Pages env vars
 - `PUBLIC_CONTACT_API_URL` — Go contact server endpoint
   (`https://api.nukehub.org/contact`).
 - `PUBLIC_CF_ANALYTICS_TOKEN` — Cloudflare Web Analytics token (optional).
-- `PUBLIC_KEYCLOAK_URL` / `PUBLIC_KEYCLOAK_REALM` / `PUBLIC_KEYCLOAK_CLIENT_ID`
-  — Keycloak IdP config for `src/lib/auth/KeycloakProvider.tsx`.
+- `PUBLIC_AUTH_URL` / `PUBLIC_AUTH_REALM` / `PUBLIC_AUTH_CLIENT_ID`
+  — NukeAuth IdP config for `src/lib/auth/NukeAuthProvider.tsx`.
 
 Secrets for the contact server (`SMTP_*`, `TURNSTILE_SECRET_KEY`,
 `ALLOWED_ORIGINS`) live in the `contact-server/` `.env`, never in this repo's

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -348,9 +348,9 @@ const commandPalettePages: CommandPalettePage[] = [
     <ErrorBoundary client:load>
       <AuthHeader
         client:only="react"
-        url={import.meta.env.PUBLIC_KEYCLOAK_URL}
-        realm={import.meta.env.PUBLIC_KEYCLOAK_REALM}
-        clientId={import.meta.env.PUBLIC_KEYCLOAK_CLIENT_ID}
+        url={import.meta.env.PUBLIC_AUTH_URL}
+        realm={import.meta.env.PUBLIC_AUTH_REALM}
+        clientId={import.meta.env.PUBLIC_AUTH_CLIENT_ID}
         projectEntries={projectNavEntries}
       />
     </ErrorBoundary>

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -38,11 +38,11 @@ All files under `src/lib/**`.
 - `useWebGL.ts` — WebGL/Three.js lifecycle helper used by home hero.
 - `auth/NukeAuthProvider.tsx` — the single auth provider.
 
-### Keycloak auth provider
+### NukeAuth provider
 
 `src/lib/auth/NukeAuthProvider.tsx` wires `keycloak-js` to a React context.
-Build-time config comes from `PUBLIC_KEYCLOAK_URL`,
-`PUBLIC_KEYCLOAK_REALM`, `PUBLIC_KEYCLOAK_CLIENT_ID`. (See root NAD
+Build-time config comes from `PUBLIC_AUTH_URL`,
+`PUBLIC_AUTH_REALM`, `PUBLIC_AUTH_CLIENT_ID`. (See root NAD
 "Environment variables".)
 
 - **Silent SSO** uses `public/silent-check-sso.html` as the iframe check


### PR DESCRIPTION
Rename `PUBLIC_KEYCLOAK_*` environment variables to `PUBLIC_AUTH_*` across
`.env.example`, `BaseLayout.astro`, and `AGENTS.md` files to match the NukeAuth provider name